### PR TITLE
Fix crash eslint if pattern not found

### DIFF
--- a/src/extract.js
+++ b/src/extract.js
@@ -29,7 +29,8 @@ function extract(code) {
       }
 
       inScript = true
-      tagStartLineNum = code.slice(0, parser.endIndex).match(/\r\n|\n|\r/g).length + 1
+      let m = code.slice(0, parser.endIndex).match(/\r\n|\n|\r/g) || []
+      tagStartLineNum = m.length + 1
     },
 
     onclosetag: function(name) {

--- a/src/extract.js
+++ b/src/extract.js
@@ -29,7 +29,7 @@ function extract(code) {
       }
 
       inScript = true
-      let m = code.slice(0, parser.endIndex).match(/\r\n|\n|\r/g) || []
+      var m = code.slice(0, parser.endIndex).match(/\r\n|\n|\r/g) || []
       tagStartLineNum = m.length + 1
     },
 


### PR DESCRIPTION
Sometimes `code.slice(0, parser.endIndex).match(/\r\n|\n|\r/g)` is null and eslint crash with `cant read length of undefined`