### PR TITLE
Add support for .riot files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ var tagProcessor = {
 module.exports = {
   processors: {
     '.html': tagProcessor,
-    '.tag': tagProcessor
+    '.tag': tagProcessor,
+    '.riot': tagProcessor
   }
 }


### PR DESCRIPTION
Riot 4 and later has changed file extension to .riot. This makes sure we process those files too.
Closes #14